### PR TITLE
[FIX] Use list instead of subtitles in the Definition document

### DIFF
--- a/Definition.md
+++ b/Definition.md
@@ -4,10 +4,10 @@
 
 This is a definition of Open Weights models, and the licenses applied to them.
 
-## The license must allow all recipients to use the models for any purpose.
-## The license must allow all recipients to modify the model for any purpose. 
-## The license must not discriminate against any user, industry, or purpose.
-## The model must be provided along with access to the NNWs as necessary to study how the model was trained. This includes information on model architecture, training methodology, hyperparameter configurations, as well as weights.
-## The software used to train the model must be provided under an open source license, or in the public domain.
-## The license must allow all recipients to provide the model, or modifications of the model, to others.
-## The license must allow any license notices or NNWs to be provided via an online reference.
+- The license must allow all recipients to use the models for any purpose.
+- The license must allow all recipients to modify the model for any purpose. 
+- The license must not discriminate against any user, industry, or purpose.
+- The model must be provided along with access to the NNWs as necessary to study how the model was trained. This includes information on model architecture, training methodology, hyperparameter configurations, as well as weights.
+- The software used to train the model must be provided under an open source license, or in the public domain.
+- The license must allow all recipients to provide the model, or modifications of the model, to others.
+- The license must allow any license notices or NNWs to be provided via an online reference.


### PR DESCRIPTION
Currently, the `Definition.md` document employs markdown subtitles (notated as `##`) to enumerate the contents of the definition. This approach, however, may need some clarification as these subtitles might be mistaken as sections that need to be filled out. 

To enhance clarity and prevent potential confusion, I suggest we change these subtitles to markdown list items (notated as `-`). This modification should make the document's structure and intention clearer to readers.

This PR aims to improve the readability and navigation of the `Definition.md` document. Any feedback or suggestions to further improve this approach are most welcome.