### PR TITLE
Add a ProseObject version of the Definition and the License 

### DIFF
--- a/Pr0b/Definition.md
+++ b/Pr0b/Definition.md
@@ -1,0 +1,21 @@
+
+Ti=The Definition
+
+
+0.sec=This is a definition of Open Weights models, and the licenses applied to them.
+
+1.sec=The license must allow all recipients to use the models for any purpose.
+
+2.sec=The license must allow all recipients to modify the model for any purpose. 
+
+3.sec=The license must not discriminate against any user, industry, or purpose.
+
+4.sec=The model must be provided along with access to the NNWs as necessary to study how the model was trained. This includes information on model architecture, training methodology, hyperparameter configurations, as well as weights.
+
+5.sec=The software used to train the model must be provided under an open source license, or in the public domain.
+
+6.sec=The license must allow all recipients to provide the model, or modifications of the model, to others.
+
+7.sec=The license must allow any license notices or NNWs to be provided via an online reference.
+
+=[G/Z/ol-bullet/s7]

--- a/Pr0b/Definition.md
+++ b/Pr0b/Definition.md
@@ -4,18 +4,32 @@ Ti=The Definition
 
 0.sec=This is a definition of Open Weights models, and the licenses applied to them.
 
-1.sec=The license must allow all recipients to use the models for any purpose.
+Use.sec=The license must allow all recipients to use the models for any purpose.
 
-2.sec=The license must allow all recipients to modify the model for any purpose. 
+Modify.sec=The license must allow all recipients to modify the model for any purpose. 
 
-3.sec=The license must not discriminate against any user, industry, or purpose.
+NotDiscriminate.sec=The license must not discriminate against any user, industry, or purpose.
 
-4.sec=The model must be provided along with access to the NNWs as necessary to study how the model was trained. This includes information on model architecture, training methodology, hyperparameter configurations, as well as weights.
+Access.sec=The model must be provided along with access to the NNWs as necessary to study how the model was trained. This includes information on model architecture, training methodology, hyperparameter configurations, as well as weights.
 
-5.sec=The software used to train the model must be provided under an open source license, or in the public domain.
+OpenSourceSoftware.sec=The software used to train the model must be provided under an open source license, or in the public domain.
 
-6.sec=The license must allow all recipients to provide the model, or modifications of the model, to others.
+Reuse.sec=The license must allow all recipients to provide the model, or modifications of the model, to others.
 
-7.sec=The license must allow any license notices or NNWs to be provided via an online reference.
+OnlineReferences.sec=The license must allow any license notices or NNWs to be provided via an online reference.
 
-=[G/Z/ol-bullet/s7]
+Use.=[G/Z/Base]
+
+Modify.=[G/Z/Base]
+
+NotDiscriminate.=[G/Z/Base]
+
+Access.=[G/Z/Base]
+
+OpenSourceSoftware.=[G/Z/Base]
+
+Reuse.=[G/Z/Base]
+
+xlist=<ul type='bullet'><li>{Use.sec}<li>{Modify.sec}<li>{NotDiscriminate.sec}<li>{Access.sec}<li>{OpenSourceSoftware.sec}<li>{Reuse.sec}</ul>
+
+=[G/Z/Base]

--- a/Pr0b/License.md
+++ b/Pr0b/License.md
@@ -1,0 +1,33 @@
+# The Model License
+
+This is an Open Weights permissive license for NNWs.
+
+Ti=Open Weights Permissive License
+
+CodersNote=Somewhat abusively using the 0.sec intro tag to get the version number into the document.
+
+0.sec=Version 1.0.0
+
+CodersNote=Have removed the "." following the titles.
+
+1.Ti=Scope 
+
+1.sec=This license covers any AI-specific elements, such as neural networks or any other type of machine learning model, artificial intelligence model, software, data, neural network, or other material that is designated as being available under this license.
+
+2.Ti=License 
+
+2.sec=The licensor grants you the rights to do everything with the licensed elements that would otherwise infringe that contributor’s intellectual property rights, including without limitation copyright, patent rights, and trade secret rights. However, this license grants you no trademark or publicity rights.
+
+3.Ti=Notices
+
+3.sec=If you modify the licensed elements and provide them to others, you may apply terms of your choice; however, if you provide any of the licensed elements to others in a manner that requires the license granted above, you must inform the recipient that the elements are available under this license, either by providing a copy of this license, or a reference to {URL TBD}.
+
+4.Ti=No Liability
+
+4.sec=As far as the law allows, each element is provided as is, without any warranty or condition, and the license will not be liable to anyone for any damages related to any licensed element or this license, under any kind of legal claim.
+
+=[G/Z/ol/4]
+
+CodersNote=Suggestion of the URL.
+
+URL TBD=<a href="https://github.com/Open-Weights/Definition/blob/main/Open%20Weights%20License.MD">https://github.com/Open-Weights/Definition/blob/main/Open%20Weights%20License.MD</a>

--- a/Pr0b/License.md
+++ b/Pr0b/License.md
@@ -10,24 +10,37 @@ CodersNote=Somewhat abusively using the 0.sec intro tag to get the version numbe
 
 CodersNote=Have removed the "." following the titles.
 
-1.Ti=Scope 
+Scope.Ti=Scope 
 
-1.sec=This license covers any AI-specific elements, such as neural networks or any other type of machine learning model, artificial intelligence model, software, data, neural network, or other material that is designated as being available under this license.
+Scope.sec=This license covers any AI-specific elements, such as neural networks or any other type of machine learning model, artificial intelligence model, software, data, neural network, or other material that is designated as being available under this license.
 
-2.Ti=License 
+License.Ti=License 
 
-2.sec=The licensor grants you the rights to do everything with the licensed elements that would otherwise infringe that contributor’s intellectual property rights, including without limitation copyright, patent rights, and trade secret rights. However, this license grants you no trademark or publicity rights.
+License.sec=The licensor grants you the rights to do everything with the licensed elements that would otherwise infringe that contributor’s intellectual property rights, including without limitation copyright, patent rights, and trade secret rights. However, this license grants you no trademark or publicity rights.
 
-3.Ti=Notices
+Notice.Ti=Notices
 
-3.sec=If you modify the licensed elements and provide them to others, you may apply terms of your choice; however, if you provide any of the licensed elements to others in a manner that requires the license granted above, you must inform the recipient that the elements are available under this license, either by providing a copy of this license, or a reference to {URL TBD}.
+Notice.sec=If you modify the licensed elements and provide them to others, you may apply terms of your choice; however, if you provide any of the licensed elements to others in a manner that requires the license granted above, you must inform the recipient that the elements are available under this license, either by providing a copy of this license, or a reference to {URL TBD}.
 
-4.Ti=No Liability
+Liability.Ti=No Liability
 
-4.sec=As far as the law allows, each element is provided as is, without any warranty or condition, and the license will not be liable to anyone for any damages related to any licensed element or this license, under any kind of legal claim.
-
-=[G/Z/ol/4]
+Liability.sec=As far as the law allows, each element is provided as is, without any warranty or condition, and the license will not be liable to anyone for any damages related to any licensed element or this license, under any kind of legal claim.
 
 CodersNote=Suggestion of the URL.
 
 URL TBD=<a href="https://github.com/Open-Weights/Definition/blob/main/Open%20Weights%20License.MD">https://github.com/Open-Weights/Definition/blob/main/Open%20Weights%20License.MD</a>
+
+
+CodersNote=Mechanics, mostly to use meaningful section names.
+
+Scope.=[G/Z/Base]
+
+License.=[G/Z/Base]
+
+Notice.=[G/Z/Base]
+
+Liability.=[G/Z/Base]
+
+xlist=<ol><li>{Scope.Sec}<li>{License.Sec}<li>{Notice.Sec}<li>{Liability.Sec}</ol>
+
+=[G/Z/Base]

--- a/Pr0b/README.md
+++ b/Pr0b/README.md
@@ -1,0 +1,6 @@
+This demos the ProseObject format for the Definition and the License.  A few notes:
+
+The license is renamed "License.md", dropping the "Open Weights" part as redundant, removing spaces as inconvenient, and making the .MD lowercase for consistency.
+
+To see these ProseObject versions rendered, go to http://www.commonaccord.org/i.php?v=l&f=G/Open-Weights/Pr0b/.
+


### PR DESCRIPTION
ProseObjects are a simple "source" format for legal text.  Unlike markdown, ProseObjects are "composable."

The sections have "semantic" labels.  These labels attempt to give a rough idea of the subject matter of the sections so that references to them evoke a bit of meaning for humans. 

They can be viewed in rendered form at http://www.commonaccord.org/i.php?v=l&f=G/Open-Weights/Pr0b/ 

The ProseObject versions are in a subdirectory called /Pr0b/ to stay out of the way of the existing markdown files. 

There are numerous fruitful naming issues in all of this, including whether the repo should have a more descriptive name than "Definition".  